### PR TITLE
fix: [#9] Switching between action tabs show tasks without throwing

### DIFF
--- a/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsPanel.java
+++ b/modules/au.com.trgtd.tr.view.actns/src/au/com/trgtd/tr/view/actns/screens/ReviewActionsPanel.java
@@ -149,7 +149,8 @@ public class ReviewActionsPanel extends JPanel implements ListSelectionListener,
         actionsTable.getActionMap().remove("find");
         actionsTable.setModel(actionsTableModel);
 
-        //actionsTable.getSelectionMapper().setEnabled(false);
+        actionsTable.setAutoCreateRowSorter(false);
+        actionsTable.setRowSorter(null);
         actionsTable.setSortable(false);
 
 //      actionsTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);

--- a/modules/au.com.trgtd.tr.view.contexts/src/au/com/trgtd/tr/view/contexts/screen/ContextsPanel.java
+++ b/modules/au.com.trgtd.tr.view.contexts/src/au/com/trgtd/tr/view/contexts/screen/ContextsPanel.java
@@ -91,7 +91,8 @@ public class ContextsPanel extends JPanel implements ListSelectionListener, Obse
         contextTable = new JXTable(contextEventTableModel);
         contextTable.getActionMap().remove("find");
         contextTable.getTableHeader().setDefaultRenderer(new JTableHeader().getDefaultRenderer());
-        //contextTable.getSelectionMapper().setEnabled(false);
+        contextTable.setAutoCreateRowSorter(false);
+        contextTable.setRowSorter(null);
         contextTable.setSortable(false);
         contextTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         contextTable.setColumnControlVisible(true);

--- a/modules/au.com.trgtd.tr.view.delegates/src/au/com/trgtd/tr/view/delegates/screen/ActorPanel.java
+++ b/modules/au.com.trgtd.tr.view.delegates/src/au/com/trgtd/tr/view/delegates/screen/ActorPanel.java
@@ -93,7 +93,8 @@ public class ActorPanel extends JPanel implements ListSelectionListener, Observe
         actorTable = new JXTable(actorEventTableModel);
         actorTable.getActionMap().remove("find");
         actorTable.getTableHeader().setDefaultRenderer(new JTableHeader().getDefaultRenderer());
-        //actorTable.getSelectionMapper().setEnabled(false);
+        actorTable.setAutoCreateRowSorter(false);
+        actorTable.setRowSorter(null);
         actorTable.setSortable(false);
         actorTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         actorTable.setColumnControlVisible(true);

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/linker/RefChooserPanel.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/linker/RefChooserPanel.java
@@ -147,7 +147,8 @@ class RefChooserPanel extends JPanel implements Observer {
         refsTableModel = new EventTableModel<Information>(refsSortedList, refsTableFormat);
         refsTable = new JXTable(refsTableModel);
         refsTable.getTableHeader().setDefaultRenderer(new JTableHeader().getDefaultRenderer());
-        //refsTable.getSelectionMapper().setEnabled(false);
+        refsTable.setAutoCreateRowSorter(false);
+        refsTable.setRowSorter(null);
         refsTable.setSortable(false);
         refsTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         refsTable.setColumnControlVisible(true);

--- a/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesPanel.java
+++ b/modules/au.com.trgtd.tr.view.reference/src/au/com/trgtd/tr/view/reference/screen/ReferencesPanel.java
@@ -98,7 +98,8 @@ public class ReferencesPanel extends JPanel implements ListSelectionListener, Ob
         
         refsTable = new JXTable(refsTableModel);
         refsTable.getTableHeader().setDefaultRenderer(new JTableHeader().getDefaultRenderer());
-        //refsTable.getSelectionMapper().setEnabled(false);
+        refsTable.setAutoCreateRowSorter(false);
+        refsTable.setRowSorter(null);
         refsTable.setSortable(false);
         refsTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         refsTable.setColumnControlVisible(true);

--- a/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedaysPanel.java
+++ b/modules/au.com.trgtd.tr.view.someday/src/au/com/trgtd/tr/view/someday/screen/SomedaysPanel.java
@@ -98,7 +98,8 @@ public class SomedaysPanel extends JPanel implements ListSelectionListener, Obse
         futuresTable = new JXTable(refsTableModel);
         futuresTable.getActionMap().remove("find");
         futuresTable.getTableHeader().setDefaultRenderer(new JTableHeader().getDefaultRenderer());
-        //futuresTable.getSelectionMapper().setEnabled(false);
+        futuresTable.setAutoCreateRowSorter(false);
+        futuresTable.setRowSorter(null);
         futuresTable.setSortable(false);
 
 //      futuresTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);

--- a/modules/au.com.trgtd.tr.view.topics/src/au/com/trgtd/tr/view/topics/screen/TopicsPanel.java
+++ b/modules/au.com.trgtd.tr.view.topics/src/au/com/trgtd/tr/view/topics/screen/TopicsPanel.java
@@ -91,7 +91,8 @@ public class TopicsPanel extends JPanel implements ListSelectionListener, Observ
         topicTable = new JXTable(topicEventTableModel);
         topicTable.getActionMap().remove("find");
         topicTable.getTableHeader().setDefaultRenderer(new JTableHeader().getDefaultRenderer());
-        //topicTable.getSelectionMapper().setEnabled(false);
+        topicTable.setAutoCreateRowSorter(false);
+        topicTable.setRowSorter(null);
         topicTable.setSortable(false);
         topicTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         topicTable.setColumnControlVisible(true);


### PR DESCRIPTION
Tackling [thinkingrock-gtd/tr-pc #9](https://github.com/thinkingrock-gtd/tr-pc/issues/9)

Resolves a left-over from the java 1.8 to 11 migration.